### PR TITLE
Add header link for email corporativo

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,6 +13,7 @@ export const Header = () => {
     { name: "Serviços", href: "/#services", type: "anchor" },
     { name: "Portfolio", href: "/#portfolio", type: "anchor" },
     { name: "Templates", href: "/templates", type: "link" },
+    { name: "E-mail Corporativo", href: "/email-corporativo", type: "link" },
     { name: "Blog", href: "/blog", type: "link" },
     { name: "Cases", href: "/cases", type: "link" },
     { name: "Contato", href: "/#contact", type: "anchor" },


### PR DESCRIPTION
## Summary
- add link to Email Corporativo page in header navigation

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6884a9a7ef6c8330a2d896439778db56