### PR TITLE
Fix Stripe checkout integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,4 @@ DB_NAME=Winove-new
 STRIPE_SECRET_KEY=sk_test_your_key_here
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 PORT=3000
-VITE_API_URL=
+VITE_API_URL=https://winove.com.br

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
+        "@stripe/stripe-js": "^7.6.1",
         "@tanstack/react-query": "^5.56.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2546,6 +2547,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.6.1.tgz",
+      "integrity": "sha512-BUDj5gujbtx53/Cexws0+aPrEBsKAN8ExPf9UfuTCivVU6ug2PjqI0zUeL1jon3795eOLlyqvCDjp6VNknjE0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@swc/core": {
       "version": "1.7.39",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.4",
+    "@stripe/stripe-js": "^7.6.1",
     "@tanstack/react-query": "^5.56.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/server/routes/checkout.js
+++ b/server/routes/checkout.js
@@ -34,7 +34,6 @@ router.post('/checkout', async (req, res) => {
   try {
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ['card'],
-      mode: 'payment',
       line_items: [
         {
           price_data: {
@@ -45,11 +44,12 @@ router.post('/checkout', async (req, res) => {
           quantity: 1,
         },
       ],
-      success_url: 'https://winove.site/sucesso',
-      cancel_url: 'https://winove.site/cancelado',
+      mode: 'payment',
+      success_url: 'https://winove.vercel.app/sucesso',
+      cancel_url: 'https://winove.vercel.app/cancelado',
     });
 
-    res.json({ url: session.url });
+    res.json({ sessionId: session.id });
   } catch (err) {
     console.error('[checkout] stripe error:', err);
     res.status(500).json({ error: 'Erro ao criar sessão de pagamento.' });

--- a/src/pages/TemplateDetail.tsx
+++ b/src/pages/TemplateDetail.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
+import { loadStripe } from "@stripe/stripe-js";
 import {
   ArrowLeft,
   Eye,
@@ -49,21 +50,21 @@ const TemplateDetail = () => {
 
   const handlePurchase = async () => {
     try {
+      const stripe = await loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY);
       const baseUrl = import.meta.env.VITE_API_URL || "";
-      const res = await fetch(`${baseUrl}/api/checkout`, {
+
+      const response = await fetch(`${baseUrl}/api/checkout`, {
         method: "POST",
         headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          id: template.slug
-        })
+        body: JSON.stringify({ id: template.slug }),
       });
 
-      const data = await res.json();
+      const { sessionId } = await response.json();
 
-      if (data?.url) {
-        window.location.href = data.url;
+      if (sessionId && stripe) {
+        await stripe.redirectToCheckout({ sessionId });
       } else {
         toast({ title: "Erro", description: "Erro ao criar sessão de pagamento." });
       }


### PR DESCRIPTION
## Summary
- return `sessionId` instead of a URL from the checkout route
- redirect to Stripe via `loadStripe` on the frontend
- set `VITE_API_URL` default in `.env.example`
- add `@stripe/stripe-js` dependency

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688519064d848330ba0b4a4c13489252