### PR TITLE
Fix MySQL imports and user casing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 DB_HOST=lweb03.appuni.com.br
 DB_PORT=3306
-DB_USER=Winove
+DB_USER=winove
 DB_PASSWORD=9*19avmU0
 DB_NAME=fernando_winove_com_br_
 STRIPE_SECRET_KEY=sk_test_your_key_here

--- a/server/app.js
+++ b/server/app.js
@@ -1,4 +1,9 @@
+import express from 'express';
+import mysql from 'mysql2/promise';
+import Stripe from 'stripe';
+import dotenv from 'dotenv';
 
+dotenv.config();
 
 const app = express();
 app.use(express.json());
@@ -7,7 +12,7 @@ app.use(express.json());
 const dbPool = mysql.createPool({
   host: process.env.DB_HOST || 'lweb03.appuni.com.br',
   port: process.env.DB_PORT ? Number(process.env.DB_PORT) : 3306,
-  user: process.env.DB_USER || 'Winove',
+  user: process.env.DB_USER || 'winove',
   password: process.env.DB_PASSWORD || '9*19avmU0',
   database: process.env.DB_NAME || 'fernando_winove_com_br_',
 });

--- a/server/db.js
+++ b/server/db.js
@@ -6,7 +6,7 @@ dotenv.config();
 const pool = mysql.createPool({
   host: process.env.DB_HOST || 'lweb03.appuni.com.br',
   port: process.env.DB_PORT ? Number(process.env.DB_PORT) : 3306,
-  user: process.env.DB_USER || 'Winove',
+  user: process.env.DB_USER || 'winove',
   password: process.env.DB_PASSWORD || '9*19avmU0',
   database: process.env.DB_NAME || 'fernando_winove_com_br_',
 });

--- a/testConnection.js
+++ b/testConnection.js
@@ -5,7 +5,7 @@ async function testConnection() {
     const connection = await mysql.createConnection({
       host: 'lweb03.appuni.com.br',
       port: 3306,
-      user: 'Winove',
+      user: 'winove',
       password: '9*19avmU0',
       database: 'fernando_winove_com_br_'
     });

--- a/testFullConnection.js
+++ b/testFullConnection.js
@@ -8,7 +8,7 @@ const execAsync = util.promisify(exec);
 // 🔧 Configurações do banco - podem ser sobrescritas por variáveis de ambiente
 const HOST = process.env.DB_HOST || 'lweb03.appuni.com.br';
 const PORT = Number(process.env.DB_PORT) || 3306;
-const USER = process.env.DB_USER || 'Winove';
+const USER = process.env.DB_USER || 'winove';
 const PASSWORD = process.env.DB_PASSWORD || '9*19avmU0';
 const DATABASE = process.env.DB_NAME || 'fernando_winove_com_br_';
 
@@ -63,4 +63,7 @@ async function conectarDB() {
   }
 }
 
-testConnection();
+(async () => {
+  await diagnosticoRede();
+  await conectarDB();
+})();


### PR DESCRIPTION
## Summary
- add missing imports to `server/app.js`
- use lowercase `winove` as default MySQL user
- fix connection test script in `testFullConnection.js`
- update `.env.example` with corrected user

## Testing
- `npm run lint`
- `npm run build`
- `node testConnection.js` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_688b5a7a4b348330a6ca0cbb1474788c