### PR TITLE
Add blog posts API endpoint

### DIFF
--- a/httpdocs/api/blog-posts.php
+++ b/httpdocs/api/blog-posts.php
@@ -1,0 +1,21 @@
+<?php
+header("Content-Type: application/json");
+
+$conn = new mysqli("localhost", "winove", "9*19avmU0", "fernando_winove_com_br_");
+
+if ($conn->connect_error) {
+  http_response_code(500);
+  echo json_encode(["error" => "Erro de conexão com o banco"]);
+  exit;
+}
+
+$result = $conn->query("SELECT id, titulo, slug, resumo, imagem, criado_em FROM blog_posts ORDER BY criado_em DESC");
+
+$posts = [];
+while ($row = $result->fetch_assoc()) {
+  $posts[] = $row;
+}
+
+echo json_encode($posts);
+$conn->close();
+?>


### PR DESCRIPTION
## Summary
- add `httpdocs/api/blog-posts.php` to serve blog post data via PHP

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688baa189a208330a1fae57852b2b454