### PR TITLE
Fix blog API fetch base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ cd <YOUR_PROJECT_NAME>
 # Step 3: Install the necessary dependencies.
 npm i
 
-# Step 4: Start the development server with auto-reloading and an instant preview.
+# Step 4: Create a `.env` file based on `.env.example` and adjust values as needed.
+cp .env.example .env
+
+# Step 5: Start the development server with auto-reloading and an instant preview.
 npm run dev
 ```
 

--- a/src/components/Blog.tsx
+++ b/src/components/Blog.tsx
@@ -24,7 +24,7 @@ export const Blog = () => {
   useEffect(() => {
     const load = async () => {
       try {
-        const baseUrl = import.meta.env.VITE_API_URL || "";
+        const baseUrl = import.meta.env.VITE_API_URL || "/api";
         const res = await fetch(`${baseUrl}/blog-posts`);
         if (res.ok) {
           const data: Post[] = await res.json();

--- a/src/pages/BlogList.tsx
+++ b/src/pages/BlogList.tsx
@@ -26,7 +26,7 @@ export const BlogList = () => {
   useEffect(() => {
     const load = async () => {
       try {
-        const baseUrl = import.meta.env.VITE_API_URL || "";
+        const baseUrl = import.meta.env.VITE_API_URL || "/api";
         const res = await fetch(`${baseUrl}/blog-posts`);
         if (res.ok) {
           const data: BlogPost[] = await res.json();

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -29,7 +29,7 @@ export const BlogPost = () => {
     const load = async () => {
       if (!slug) return;
       try {
-        const baseUrl = import.meta.env.VITE_API_URL || "";
+        const baseUrl = import.meta.env.VITE_API_URL || "/api";
         const res = await fetch(`${baseUrl}/blog-posts/${slug}`);
         if (res.ok) {
           const data: BlogPost = await res.json();

--- a/src/pages/CaseDetail.tsx
+++ b/src/pages/CaseDetail.tsx
@@ -28,7 +28,7 @@ export const CaseDetail = () => {
     const load = async () => {
       if (!slug) return;
       try {
-        const baseUrl = import.meta.env.VITE_API_URL || "";
+        const baseUrl = import.meta.env.VITE_API_URL || "/api";
         const res = await fetch(`${baseUrl}/cases/${slug}`);
         if (res.ok) {
           const data = await res.json();

--- a/src/pages/CasesList.tsx
+++ b/src/pages/CasesList.tsx
@@ -25,7 +25,7 @@ export const CasesList = () => {
   useEffect(() => {
     const load = async () => {
       try {
-        const baseUrl = import.meta.env.VITE_API_URL || "";
+        const baseUrl = import.meta.env.VITE_API_URL || "/api";
         const res = await fetch(`${baseUrl}/cases`);
         const data = await res.json();
         setItems(data);

--- a/src/pages/TemplateDetail.tsx
+++ b/src/pages/TemplateDetail.tsx
@@ -51,7 +51,7 @@ const TemplateDetail = () => {
   const handlePurchase = async () => {
     try {
       const stripe = await loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY);
-      const baseUrl = import.meta.env.VITE_API_URL || "";
+      const baseUrl = import.meta.env.VITE_API_URL || "/api";
 
       const response = await fetch(`${baseUrl}/checkout`, {
         method: "POST",


### PR DESCRIPTION
## Summary
- default blog fetch base URL to `/api` when VITE_API_URL isn't set
- document creating an `.env` file before running the dev server

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688baf277f288330847055910ad77fa9