### PR TITLE
Fix API URL handling in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ cd <YOUR_PROJECT_NAME>
 # Step 3: Install the necessary dependencies.
 npm i
 
-# Step 4: Create a `.env` file based on `.env.example` and adjust values as needed.
+# Step 4: Create a `.env` file based on `.env.example` (required for builds).
 cp .env.example .env
+# Ensure the `VITE_API_URL` variable is present. For production it should be
+# `https://winove.com.br/api`.
 
 # Step 5: Start the development server with auto-reloading and an instant preview.
 npm run dev
@@ -74,6 +76,10 @@ The local server relies on the following packages:
 ## How can I deploy this project?
 
 Simply open [Winove](https://lovable.dev/projects/47e97737-0d5b-4617-a6fc-0cc3a9fb4b6b) and click on Share -> Publish.
+
+When building locally or running `deploy.sh`, make sure a `.env` file exists
+with `VITE_API_URL` defined. The provided `deploy.sh` script will create a
+minimal `.env` automatically.
 
 ## Can I connect a custom domain to my Winove project?
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,7 @@
 set -e
 
 # Build the project with hashed assets
+echo "VITE_API_URL=https://winove.com.br/api" > .env
 npm run build
 
 if [ -z "$DEPLOY_USER" ] || [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_PATH" ]; then

--- a/src/components/Blog.tsx
+++ b/src/components/Blog.tsx
@@ -24,8 +24,8 @@ export const Blog = () => {
   useEffect(() => {
     const load = async () => {
       try {
-        const baseUrl = import.meta.env.VITE_API_URL || "/api";
-        const res = await fetch(`${baseUrl}/blog-posts`);
+        const API = import.meta.env.VITE_API_URL || "/api";
+        const res = await fetch(`${API}/blog-posts`);
         if (res.ok) {
           const data: Post[] = await res.json();
           setArticles(data.slice(0, 6));

--- a/src/pages/BlogList.tsx
+++ b/src/pages/BlogList.tsx
@@ -26,8 +26,8 @@ export const BlogList = () => {
   useEffect(() => {
     const load = async () => {
       try {
-        const baseUrl = import.meta.env.VITE_API_URL || "/api";
-        const res = await fetch(`${baseUrl}/blog-posts`);
+        const API = import.meta.env.VITE_API_URL || "/api";
+        const res = await fetch(`${API}/blog-posts`);
         if (res.ok) {
           const data: BlogPost[] = await res.json();
           setPosts(data.slice(0, 6));

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -29,12 +29,12 @@ export const BlogPost = () => {
     const load = async () => {
       if (!slug) return;
       try {
-        const baseUrl = import.meta.env.VITE_API_URL || "/api";
-        const res = await fetch(`${baseUrl}/blog-posts/${slug}`);
+        const API = import.meta.env.VITE_API_URL || "/api";
+        const res = await fetch(`${API}/blog-posts/${slug}`);
         if (res.ok) {
           const data: BlogPost = await res.json();
           setPost(data);
-          const relRes = await fetch(`${baseUrl}/blog-posts`);
+          const relRes = await fetch(`${API}/blog-posts`);
           if (relRes.ok) {
             const all: BlogPost[] = await relRes.json();
             setRelatedPosts(all.filter((p) => p.slug !== data.slug).slice(0, 3));

--- a/src/pages/CaseDetail.tsx
+++ b/src/pages/CaseDetail.tsx
@@ -28,12 +28,12 @@ export const CaseDetail = () => {
     const load = async () => {
       if (!slug) return;
       try {
-        const baseUrl = import.meta.env.VITE_API_URL || "/api";
-        const res = await fetch(`${baseUrl}/cases/${slug}`);
+        const API = import.meta.env.VITE_API_URL || "/api";
+        const res = await fetch(`${API}/cases/${slug}`);
         if (res.ok) {
           const data = await res.json();
           setCaseItem(data);
-          const relRes = await fetch(`${baseUrl}/cases`);
+          const relRes = await fetch(`${API}/cases`);
           if (relRes.ok) {
             const all = await relRes.json();
             setRelatedCases(all.filter((c: CaseItem) => c.slug !== data.slug).slice(0, 3));

--- a/src/pages/CasesList.tsx
+++ b/src/pages/CasesList.tsx
@@ -25,8 +25,8 @@ export const CasesList = () => {
   useEffect(() => {
     const load = async () => {
       try {
-        const baseUrl = import.meta.env.VITE_API_URL || "/api";
-        const res = await fetch(`${baseUrl}/cases`);
+        const API = import.meta.env.VITE_API_URL || "/api";
+        const res = await fetch(`${API}/cases`);
         const data = await res.json();
         setItems(data);
       } catch (err) {

--- a/src/pages/TemplateDetail.tsx
+++ b/src/pages/TemplateDetail.tsx
@@ -51,9 +51,9 @@ const TemplateDetail = () => {
   const handlePurchase = async () => {
     try {
       const stripe = await loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY);
-      const baseUrl = import.meta.env.VITE_API_URL || "/api";
+      const API = import.meta.env.VITE_API_URL || "/api";
 
-      const response = await fetch(`${baseUrl}/checkout`, {
+      const response = await fetch(`${API}/checkout`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- fetch API base URL from `VITE_API_URL` with `/api` fallback
- ensure `deploy.sh` writes `.env` before building
- clarify environment setup and deployment steps in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bb1d17e7c83309cee697f20f61dfe