### PR TITLE
feat: add offline JSON data mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ mysql -u fernandowinove -p Winove-new < winove_offline.sql
 
 You can also use phpMyAdmin or another GUI to import the file manually.
 
+## Offline JSON mode
+
+For development without a running MySQL server, set `USE_JSON_DB=true` in
+`backend/.env`. The API will then read data from the JSON files located in
+`backend/data/`, allowing the blog and cases pages to function entirely
+offline.
+
 ## Testing database connectivity
 
 Use the `testFullConnection.js` script to diagnose network issues and test the

--- a/backend/data/blog-posts.json
+++ b/backend/data/blog-posts.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": 1,
+    "titulo": "Bem-vindo ao Blog",
+    "slug": "bem-vindo-ao-blog",
+    "resumo": "Post inaugural dando boas vindas ao blog.",
+    "conteudo": "<p>Este é o nosso primeiro post no blog!</p>",
+    "imagem_destacada": "https://exemplo.com/post1.jpg",
+    "data_publicacao": "2025-07-31 16:20:27",
+    "autor": "Admin"
+  },
+  {
+    "id": 2,
+    "titulo": "Novidades da Plataforma",
+    "slug": "novidades-da-plataforma",
+    "resumo": "Veja o que mudou na última atualização.",
+    "conteudo": "<p>Muitas melhorias implementadas.</p>",
+    "imagem_destacada": "https://exemplo.com/post2.jpg",
+    "data_publicacao": "2025-07-31 16:20:27",
+    "autor": "Admin"
+  },
+  {
+    "id": 3,
+    "titulo": "Dicas de Produtividade",
+    "slug": "dicas-de-produtividade",
+    "resumo": "Pequenas ações para melhorar seu dia a dia.",
+    "conteudo": "<p>Confira nossas dicas valiosas.</p>",
+    "imagem_destacada": "https://exemplo.com/post3.jpg",
+    "data_publicacao": "2025-07-31 16:20:27",
+    "autor": "Equipe Winove"
+  }
+]

--- a/backend/data/cases.json
+++ b/backend/data/cases.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": 1,
+    "title": "E-commerce Moderno para Moda",
+    "slug": "ecommerce-moderno-moda",
+    "excerpt": "Desenvolvimento de plataforma e-commerce completa com foco em conversão e experiência do usuário.",
+    "coverImage": "https://images.unsplash.com/photo-1441986300917-64674bd600d8?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80",
+    "tags": ["E-commerce", "UX/UI", "Desenvolvimento"],
+    "metrics": {"conversao": "+250%", "vendas": "+180%", "usuarios": "50k+"},
+    "gallery": [],
+    "content": "<p>Projeto completo de e-commerce para marca de moda...</p>",
+    "client": "FashionBrand",
+    "category": "E-commerce",
+    "created_at": "2025-07-31 23:39:36"
+  },
+  {
+    "id": 2,
+    "title": "App Mobile para Delivery",
+    "slug": "app-mobile-delivery",
+    "excerpt": "Aplicativo mobile nativo para delivery de comida com sistema de rastreamento em tempo real.",
+    "coverImage": "https://images.unsplash.com/photo-1563013544-824ae1b704d3?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80",
+    "tags": ["Mobile", "React Native", "Backend"],
+    "metrics": {"downloads": "100k+", "rating": "4.8", "pedidos": "10k+"},
+    "gallery": [],
+    "content": "<p>Desenvolvimento de aplicativo mobile completo...</p>",
+    "client": "DeliveryApp",
+    "category": "Mobile",
+    "created_at": "2025-07-31 23:39:36"
+  },
+  {
+    "id": 3,
+    "title": "Sistema SaaS para Gestão",
+    "slug": "sistema-saas-gestao",
+    "excerpt": "Plataforma SaaS completa para gestão empresarial com dashboard em tempo real e relatórios avançados.",
+    "coverImage": "https://images.unsplash.com/photo-1551434678-e076c223a692?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80",
+    "tags": ["SaaS", "Dashboard", "Analytics"],
+    "metrics": {"usuarios": "5k+", "uptime": "99.9%", "satisfacao": "95%"},
+    "gallery": [],
+    "content": "<p>Sistema SaaS completo para gestão empresarial...</p>",
+    "client": "GestãoPro",
+    "category": "SaaS",
+    "created_at": "2025-07-31 23:39:36"
+  }
+]

--- a/backend/routes/blogPosts.js
+++ b/backend/routes/blogPosts.js
@@ -1,9 +1,22 @@
 const express = require('express');
+const fs = require('fs');
+const path = require('path');
 const db = require('../db');
 
 const router = express.Router();
+const useJsonDb = process.env.USE_JSON_DB === 'true';
+const postsFile = path.join(__dirname, '../data/blog-posts.json');
 
 router.get('/blog-posts', async (_req, res) => {
+  if (useJsonDb) {
+    try {
+      const posts = JSON.parse(fs.readFileSync(postsFile, 'utf-8'));
+      return res.json(posts);
+    } catch (err) {
+      console.error('[blog-posts-offline]', err);
+      return res.status(500).json({ error: 'Failed to read blog posts file' });
+    }
+  }
   try {
     const queryAll =
       'SELECT id, title as titulo, slug, excerpt as resumo, content as conteudo, cover_image as imagem_destacada, date as data_publicacao, author as autor FROM blog_posts ORDER BY date DESC';
@@ -16,6 +29,17 @@ router.get('/blog-posts', async (_req, res) => {
 });
 
 router.get('/blog-posts/:slug', async (req, res) => {
+  if (useJsonDb) {
+    try {
+      const posts = JSON.parse(fs.readFileSync(postsFile, 'utf-8'));
+      const post = posts.find((p) => p.slug === req.params.slug);
+      if (!post) return res.status(404).json({ error: 'Post not found' });
+      return res.json(post);
+    } catch (err) {
+      console.error('[blog-post-offline]', err);
+      return res.status(500).json({ error: 'Failed to read blog post file' });
+    }
+  }
   try {
     const { slug } = req.params;
     const queryOne =

--- a/backend/routes/cases.js
+++ b/backend/routes/cases.js
@@ -1,7 +1,11 @@
 const express = require('express');
+const fs = require('fs');
+const path = require('path');
 const db = require('../db');
 
 const router = express.Router();
+const useJsonDb = process.env.USE_JSON_DB === 'true';
+const casesFile = path.join(__dirname, '../data/cases.json');
 
 function parseJson(value) {
   try {
@@ -12,6 +16,15 @@ function parseJson(value) {
 }
 
 router.get('/cases', async (_req, res) => {
+  if (useJsonDb) {
+    try {
+      const cases = JSON.parse(fs.readFileSync(casesFile, 'utf-8'));
+      return res.json(cases);
+    } catch (err) {
+      console.error('[cases-offline]', err);
+      return res.status(500).json({ error: 'Failed to read cases file' });
+    }
+  }
   try {
     const [rows] = await db.query('SELECT id, title, slug, excerpt, coverImage, tags, metrics FROM cases ORDER BY id DESC');
     const cases = rows.map((r) => ({
@@ -27,6 +40,17 @@ router.get('/cases', async (_req, res) => {
 });
 
 router.get('/cases/:slug', async (req, res) => {
+  if (useJsonDb) {
+    try {
+      const cases = JSON.parse(fs.readFileSync(casesFile, 'utf-8'));
+      const c = cases.find((caseItem) => caseItem.slug === req.params.slug);
+      if (!c) return res.status(404).json({ error: 'Case not found' });
+      return res.json(c);
+    } catch (err) {
+      console.error('[case-offline]', err);
+      return res.status(500).json({ error: 'Failed to read case file' });
+    }
+  }
   try {
     const { slug } = req.params;
     const [rows] = await db.query('SELECT * FROM cases WHERE slug = ?', [slug]);


### PR DESCRIPTION
## Summary
- add JSON fixtures for blog posts and cases
- enable API to serve data from JSON files when `USE_JSON_DB=true`
- document offline JSON mode in README

## Testing
- `npm test` (backend) – fails: Missing script: "test"
- `npm test` (frontend) – fails: Missing script: "test"

------
https://chatgpt.com/codex/tasks/task_e_688d381b66f88330989e1b47bb815185