### PR TITLE
feat: make API URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ npm i
 cp .env.example .env
 # Ensure the `VITE_API_URL` variable is present. For production it should be
 # `https://winove.com.br/api`.
+# When the backend is served from a different domain or port, set
+# `VITE_API_URL` to that backend's base URL (e.g. `https://example.com/api`).
+# If undefined, the application defaults to `/api` and assumes the backend is
+# hosted under the same domain.
 
 # Step 5: Start the development server with auto-reloading and an instant preview.
 npm run dev

--- a/frontend/src/pages/BlogList.tsx
+++ b/frontend/src/pages/BlogList.tsx
@@ -25,8 +25,9 @@ export const BlogList = () => {
 
   useEffect(() => {
     const load = async () => {
+      const API = import.meta.env.VITE_API_URL || "/api";
       try {
-        const res = await fetch("/api/blog-posts");
+        const res = await fetch(`${API}/blog-posts`);
         if (res.ok) {
           const data: BlogPost[] = await res.json();
           setPosts(data.slice(0, 6));

--- a/frontend/src/pages/BlogPost.tsx
+++ b/frontend/src/pages/BlogPost.tsx
@@ -28,12 +28,13 @@ export const BlogPost = () => {
   useEffect(() => {
     const load = async () => {
       if (!slug) return;
+      const API = import.meta.env.VITE_API_URL || "/api";
       try {
-        const res = await fetch(`/api/blog-posts/${slug}`);
+        const res = await fetch(`${API}/blog-posts/${slug}`);
         if (res.ok) {
           const data: BlogPost = await res.json();
           setPost(data);
-          const relRes = await fetch(`/api/blog-posts`);
+          const relRes = await fetch(`${API}/blog-posts`);
           if (relRes.ok) {
             const allPosts: BlogPost[] = await relRes.json();
             const related = allPosts.filter(p => p.slug !== slug).slice(0, 3);


### PR DESCRIPTION
## Summary
- allow frontend pages to use configurable API URL
- document VITE_API_URL variable for custom backend origins

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d404e0d208330b2d1f614c8b3ceb2