### PR TITLE
Serve frontend build with SPA fallback in Express

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
+const path = require('path');
 
 dotenv.config();
 
@@ -15,6 +16,15 @@ app.use(express.json());
 app.use('/api', checkoutRoute);
 app.use('/api', casesRoute);
 app.use('/api', blogRoute);
+
+// Servir arquivos estáticos do build do frontend
+const distPath = path.join(__dirname, 'dist');
+app.use(express.static(distPath));
+
+// Rota curinga para suportar SPA
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(distPath, 'index.html'));
+});
 
 const port = process.env.PORT || 3333;
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- serve frontend build from backend/dist
- add wildcard route to return index.html for non-API requests

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689ce9b65660833092d579f07fc59924