### PR TITLE
Fix API column selections for blog posts and cases

### DIFF
--- a/backend/routes/blogPosts.js
+++ b/backend/routes/blogPosts.js
@@ -12,7 +12,7 @@ router.get('/', async (_req, res) => {
         titulo AS title,
         slug,
         resumo AS excerpt,
-        imagem_destacada AS cover_image,
+        imagem_destacada AS coverImage,
         data_publicacao AS date,
         autor AS author
       FROM blog_posts
@@ -36,7 +36,7 @@ router.get('/:slug', async (req, res) => {
         slug,
         resumo AS excerpt,
         conteudo AS content,
-        imagem_destacada AS cover_image,
+        imagem_destacada AS coverImage,
         data_publicacao AS date,
         autor AS author
       FROM blog_posts

--- a/backend/routes/cases.js
+++ b/backend/routes/cases.js
@@ -21,23 +21,23 @@ const parseJSONField = (value) => {
 // Lista todos os cases
 router.get('/', async (_req, res) => {
   try {
+    // Seleciona apenas colunas existentes na tabela `cases` e alia created_at para date.
     const [rows] = await pool.query(`
-      SELECT 
+      SELECT
         id,
         title,
         slug,
         excerpt,
         coverImage,
+        content,
         client,
-        date,
-        challenge,
-        solution,
-        results,
-        gallery,
+        category,
+        created_at AS date,
         tags,
-        metrics
+        metrics,
+        gallery
       FROM cases
-      ORDER BY id DESC
+      ORDER BY created_at DESC, id DESC
     `);
     // Converte campos JSON (tags, gallery, metrics) para arrays/objetos
     const data = rows.map(row => {
@@ -58,24 +58,23 @@ router.get('/:slug', async (req, res) => {
   try {
     const [rows] = await pool.query(
       `
-      SELECT 
+      SELECT
         id,
         title,
         slug,
         excerpt,
         coverImage,
+        content,
         client,
-        date,
-        challenge,
-        solution,
-        results,
-        gallery,
+        category,
+        created_at AS date,
         tags,
-        metrics
+        metrics,
+        gallery
       FROM cases
       WHERE slug = ?
       LIMIT 1
-    `,
+      `,
       [req.params.slug]
     );
     if (rows.length === 0) {


### PR DESCRIPTION
## Summary
- Align blog post routes with front-end by aliasing `imagem_destacada` as `coverImage`
- Update case routes to query existing columns and return `created_at` as `date`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d026d10488330b9a6a37f593f687c