### PR TITLE
Fix blog and case routes to match MySQL schema

### DIFF
--- a/backend/routes/blogPosts.js
+++ b/backend/routes/blogPosts.js
@@ -9,12 +9,13 @@ router.get('/', async (_req, res) => {
     const [rows] = await pool.query(`
       SELECT
         id,
-        titulo AS title,
+        titulo,
         slug,
-        resumo AS excerpt,
-        imagem_destacada AS coverImage,
-        data_publicacao AS date,
-        autor AS author
+        resumo,
+        conteudo,
+        imagem_destacada,
+        data_publicacao,
+        autor
       FROM blog_posts
       ORDER BY data_publicacao DESC, id DESC
     `);
@@ -32,13 +33,13 @@ router.get('/:slug', async (req, res) => {
       `
       SELECT
         id,
-        titulo AS title,
+        titulo,
         slug,
-        resumo AS excerpt,
-        conteudo AS content,
-        imagem_destacada AS coverImage,
-        data_publicacao AS date,
-        autor AS author
+        resumo,
+        conteudo,
+        imagem_destacada,
+        data_publicacao,
+        autor
       FROM blog_posts
       WHERE slug = ?
       LIMIT 1

--- a/backend/routes/cases.js
+++ b/backend/routes/cases.js
@@ -21,7 +21,7 @@ const parseJSONField = (value) => {
 // Lista todos os cases
 router.get('/', async (_req, res) => {
   try {
-    // Seleciona apenas colunas existentes na tabela `cases` e alia created_at para date.
+    // Seleciona apenas colunas existentes na tabela `cases`.
     const [rows] = await pool.query(`
       SELECT
         id,
@@ -32,7 +32,7 @@ router.get('/', async (_req, res) => {
         content,
         client,
         category,
-        created_at AS date,
+        created_at,
         tags,
         metrics,
         gallery
@@ -67,7 +67,7 @@ router.get('/:slug', async (req, res) => {
         content,
         client,
         category,
-        created_at AS date,
+        created_at,
         tags,
         metrics,
         gallery


### PR DESCRIPTION
## Summary
- Align blog posts queries with Portuguese column names
- Remove created_at alias and query cases with existing column names

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d07cf6b688330a462bb3f9e7803ec