### PR TITLE
Fix blog and case routes to match MySQL schema

### DIFF
--- a/backend/routes/blogPosts.js
+++ b/backend/routes/blogPosts.js
@@ -9,12 +9,13 @@ router.get('/', async (_req, res) => {
     const [rows] = await pool.query(`
       SELECT
         id,
-        titulo AS title,
+        titulo,
         slug,
-        resumo AS excerpt,
-        imagem_destacada AS coverImage,
-        data_publicacao AS date,
-        autor AS author
+        resumo,
+        conteudo,
+        imagem_destacada,
+        data_publicacao,
+        autor
       FROM blog_posts
       ORDER BY data_publicacao DESC, id DESC
     `);
@@ -32,13 +33,13 @@ router.get('/:slug', async (req, res) => {
       `
       SELECT
         id,
-        titulo AS title,
+        titulo,
         slug,
-        resumo AS excerpt,
-        conteudo AS content,
-        imagem_destacada AS coverImage,
-        data_publicacao AS date,
-        autor AS author
+        resumo,
+        conteudo,
+        imagem_destacada,
+        data_publicacao,
+        autor
       FROM blog_posts
       WHERE slug = ?
       LIMIT 1

--- a/backend/routes/cases.js
+++ b/backend/routes/cases.js
@@ -18,10 +18,29 @@ const parseJSONField = (value) => {
   return value;
 };
 
+// Normaliza o campo metrics para sempre retornar um array de objetos
+const parseMetricsField = (value) => {
+  const parsed = parseJSONField(value);
+  if (Array.isArray(parsed)) return parsed;
+  if (parsed && typeof parsed === 'object') {
+    return Object.entries(parsed).map(([label, val]) => {
+      if (val && typeof val === 'object') {
+        return {
+          label,
+          value: String(val.value ?? ''),
+          description: val.description ?? ''
+        };
+      }
+      return { label, value: String(val) };
+    });
+  }
+  return [];
+};
+
 // Lista todos os cases
 router.get('/', async (_req, res) => {
   try {
-    // Seleciona apenas colunas existentes na tabela `cases` e alia created_at para date.
+    // Seleciona apenas colunas existentes na tabela `cases`.
     const [rows] = await pool.query(`
       SELECT
         id,
@@ -43,7 +62,7 @@ router.get('/', async (_req, res) => {
     const data = rows.map(row => {
       const tags = parseJSONField(row.tags) ?? [];
       const gallery = parseJSONField(row.gallery) ?? [];
-      const metrics = parseJSONField(row.metrics) ?? {};
+      const metrics = parseMetricsField(row.metrics);
       return { ...row, tags, gallery, metrics };
     });
     res.json(data);
@@ -86,7 +105,7 @@ router.get('/:slug', async (req, res) => {
       ...row,
       tags: parseJSONField(row.tags) ?? [],
       gallery: parseJSONField(row.gallery) ?? [],
-      metrics: parseJSONField(row.metrics) ?? {}
+      metrics: parseMetricsField(row.metrics)
     };
     res.json(data);
   } catch (err) {

--- a/frontend/src/components/Portfolio.tsx
+++ b/frontend/src/components/Portfolio.tsx
@@ -107,7 +107,7 @@ export const Portfolio = () => {
                   {/* Project Image */}
                   <div className="relative h-48 overflow-hidden">
                     <img
-                      src={`https://images.unsplash.com/${project.image}?w=600&h=400&fit=crop`}
+                      src={project.image}
                       alt={project.title}
                       className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                     />

--- a/frontend/src/pages/CaseDetail.tsx
+++ b/frontend/src/pages/CaseDetail.tsx
@@ -152,7 +152,7 @@ export const CaseDetail = () => {
               {/* Featured Image */}
               <div className="relative h-64 md:h-96 overflow-hidden rounded-2xl">
                 <img
-                  src={`https://images.unsplash.com/${caseItem.coverImage}?w=800&h=600&fit=crop`}
+                  src={caseItem.coverImage}
                   alt={caseItem.title}
                   className="w-full h-full object-cover"
                 />
@@ -267,7 +267,7 @@ export const CaseDetail = () => {
                     style={{ animationDelay: `${index * 0.1}s` }}
                   >
                     <img
-                      src={`https://images.unsplash.com/${image}?w=600&h=400&fit=crop`}
+                      src={image}
                       alt={`${caseItem.title} - Imagem ${index + 1}`}
                       className="w-full h-full object-cover transition-transform duration-500 hover:scale-110"
                     />
@@ -296,7 +296,7 @@ export const CaseDetail = () => {
                   <article key={relatedCase.slug} className="glass rounded-2xl overflow-hidden hover-lift group">
                     <div className="relative h-48 overflow-hidden">
                       <img
-                        src={`https://images.unsplash.com/${relatedCase.coverImage}?w=400&h=300&fit=crop`}
+                        src={relatedCase.coverImage}
                         alt={relatedCase.title}
                         className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                       />

--- a/frontend/src/pages/CasesList.tsx
+++ b/frontend/src/pages/CasesList.tsx
@@ -108,7 +108,7 @@ export const CasesList = () => {
                   {/* Case Image */}
                   <div className="relative h-64 overflow-hidden">
                     <img
-                      src={`https://images.unsplash.com/${caseItem.coverImage}?w=800&h=400&fit=crop`}
+                      src={caseItem.coverImage}
                       alt={caseItem.title}
                       className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                     />


### PR DESCRIPTION
## Summary
- Align blog posts queries with Portuguese column names
- Query cases with existing columns and expose creation date under `date`
- Normalize case metrics into arrays so detail pages can render without errors
- Render case images using full `coverImage` URLs instead of Unsplash IDs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd backend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d07cf6b688330a462bb3f9e7803ec