### PR TITLE
Serve built frontend from backend

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,6 +1,8 @@
 import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import casesRoute from './routes/cases.js';
 import blogRoute from './routes/blogPosts.js';
 import checkoutRoute from './routes/checkout.js';
@@ -10,9 +12,17 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 app.use('/api', casesRoute);
 app.use('/api', blogRoute);
 app.use('/api', checkoutRoute);
+
+app.use(express.static(path.resolve(__dirname, '../frontend/dist')));
+app.get('*', (_req, res) => {
+  res.sendFile(path.resolve(__dirname, '../frontend/dist/index.html'));
+});
 
 const port = process.env.PORT || 3333;
 app.listen(port, () => console.log(`API on :${port}`));


### PR DESCRIPTION
## Summary
- Build frontend assets
- Serve built frontend via Express with static file middleware and catch-all route

## Testing
- `npm run build` inside `frontend`
- `npm test` inside `backend` *(fails: Missing script)*
- `npm test` inside `frontend` *(fails: Missing script)*
- `node backend/index.js` & `curl -I http://localhost:3333`


------
https://chatgpt.com/codex/tasks/task_e_689d46f614508330aa2fc7baa553e4b3