### PR TITLE
Enable ES modules for backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "winove-server",
   "version": "1.0.0",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",


### PR DESCRIPTION
## Summary
- enable ECMAScript module syntax by setting `type: module` in backend package.json

## Testing
- `npm start` *(fails: The requested module './routes/checkout.js' does not provide an export named 'default')*

------
https://chatgpt.com/codex/tasks/task_e_689d48924ce48330b2792ba68c94d343