### PR TITLE
Align blog API with database columns

### DIFF
--- a/backend/routes/blogPosts.js
+++ b/backend/routes/blogPosts.js
@@ -9,13 +9,13 @@ router.get('/', async (_req, res) => {
     const [rows] = await pool.query(`
       SELECT
         id,
-        titulo,
+        titulo AS title,
         slug,
-        resumo,
-        conteudo,
-        imagem_destacada,
-        data_publicacao,
-        autor
+        resumo AS excerpt,
+        conteudo AS content,
+        imagem_destacada AS coverImage,
+        data_publicacao AS date,
+        autor AS author
       FROM blog_posts
       ORDER BY data_publicacao DESC, id DESC
     `);
@@ -33,13 +33,13 @@ router.get('/:slug', async (req, res) => {
       `
       SELECT
         id,
-        titulo,
+        titulo AS title,
         slug,
-        resumo,
-        conteudo,
-        imagem_destacada,
-        data_publicacao,
-        autor
+        resumo AS excerpt,
+        conteudo AS content,
+        imagem_destacada AS coverImage,
+        data_publicacao AS date,
+        autor AS author
       FROM blog_posts
       WHERE slug = ?
       LIMIT 1

--- a/frontend/src/components/Blog.tsx
+++ b/frontend/src/components/Blog.tsx
@@ -4,13 +4,13 @@ import { useEffect, useState } from "react";
 
 interface Post {
   id: number;
-  titulo: string;
+  title: string;
   slug: string;
-  resumo: string;
-  conteudo: string;
-  imagem_destacada: string;
-  data_publicacao: string;
-  autor: string;
+  excerpt: string;
+  content: string;
+  coverImage: string;
+  date: string;
+  author: string;
 }
 
 function readingTime(content: string): string {
@@ -84,8 +84,8 @@ export const Blog = () => {
                   {/* Article Image */}
                   <div className="relative h-48 overflow-hidden">
                     <img
-                      src={article.imagem_destacada}
-                      alt={article.titulo}
+                      src={article.coverImage}
+                      alt={article.title}
                       className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                     />
                     <div className="absolute inset-0 bg-gradient-to-t from-background/60 to-transparent" />
@@ -93,7 +93,7 @@ export const Blog = () => {
                     {/* Read Time */}
                     <div className="absolute top-4 right-4">
                       <span className="px-3 py-1 text-xs font-medium rounded-full glass text-muted-foreground border border-border/20">
-                        {readingTime(article.conteudo)}
+                        {readingTime(article.content)}
                       </span>
                     </div>
                   </div>
@@ -101,22 +101,22 @@ export const Blog = () => {
                   {/* Article Content */}
                   <div className="p-6">
                     <h3 className="text-xl font-bold mb-3 text-foreground line-clamp-2 group-hover:text-primary transition-colors duration-300">
-                      {article.titulo}
+                      {article.title}
                     </h3>
 
                     <p className="text-muted-foreground mb-4 text-sm line-clamp-3">
-                      {article.resumo}
+                      {article.excerpt}
                     </p>
 
                     {/* Article Meta */}
                     <div className="flex items-center justify-between text-xs text-muted-foreground mb-4">
                       <div className="flex items-center gap-2">
                         <User className="w-4 h-4" />
-                        <span>{article.autor}</span>
+                        <span>{article.author}</span>
                       </div>
                       <div className="flex items-center gap-2">
                         <Calendar className="w-4 h-4" />
-                        <span>{new Date(article.data_publicacao).toLocaleDateString('pt-BR')}</span>
+                        <span>{new Date(article.date).toLocaleDateString('pt-BR')}</span>
                       </div>
                     </div>
 

--- a/frontend/src/pages/BlogList.tsx
+++ b/frontend/src/pages/BlogList.tsx
@@ -6,13 +6,13 @@ import { Footer } from "@/components/Footer";
 
 interface BlogPost {
   id: number;
-  titulo: string;
+  title: string;
   slug: string;
-  resumo: string;
-  conteudo: string;
-  imagem_destacada: string;
-  data_publicacao: string;
-  autor: string;
+  excerpt: string;
+  content: string;
+  coverImage: string;
+  date: string;
+  author: string;
 }
 
 function calcReadingTime(content: string): string {
@@ -91,8 +91,8 @@ export const BlogList = () => {
                   {/* Post Image */}
                   <div className="relative h-48 overflow-hidden">
                     <img
-                      src={post.imagem_destacada}
-                      alt={post.titulo}
+                      src={post.coverImage}
+                      alt={post.title}
                       className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                     />
                     <div className="absolute inset-0 bg-gradient-to-t from-background/60 to-transparent" />
@@ -100,7 +100,7 @@ export const BlogList = () => {
                     {/* Read Time */}
                     <div className="absolute top-4 right-4">
                       <span className="px-3 py-1 text-xs font-medium rounded-full glass text-muted-foreground border border-border/20">
-                        {`${calcReadingTime(post.conteudo)} min`}
+                        {`${calcReadingTime(post.content)} min`}
                       </span>
                     </div>
                   </div>
@@ -108,22 +108,22 @@ export const BlogList = () => {
                   {/* Post Content */}
                   <div className="p-6">
                     <h3 className="text-xl font-bold mb-3 text-foreground line-clamp-2 group-hover:text-primary transition-colors duration-300">
-                      {post.titulo}
+                      {post.title}
                     </h3>
 
                     <p className="text-muted-foreground mb-4 text-sm line-clamp-3">
-                      {post.resumo}
+                      {post.excerpt}
                     </p>
 
                     {/* Post Meta */}
                     <div className="flex items-center justify-between text-xs text-muted-foreground mb-4">
                       <div className="flex items-center gap-2">
                         <User className="w-4 h-4" />
-                        <span>{post.autor}</span>
+                        <span>{post.author}</span>
                       </div>
                       <div className="flex items-center gap-2">
                         <Calendar className="w-4 h-4" />
-                        <span>{new Date(post.data_publicacao).toLocaleDateString('pt-BR')}</span>
+                        <span>{new Date(post.date).toLocaleDateString('pt-BR')}</span>
                       </div>
                     </div>
 

--- a/frontend/src/pages/BlogPost.tsx
+++ b/frontend/src/pages/BlogPost.tsx
@@ -6,13 +6,13 @@ import { useEffect, useState } from "react";
 
 interface BlogPost {
   id: number;
-  titulo: string;
+  title: string;
   slug: string;
-  resumo: string;
-  conteudo: string;
-  imagem_destacada: string;
-  data_publicacao: string;
-  autor: string;
+  excerpt: string;
+  content: string;
+  coverImage: string;
+  date: string;
+  author: string;
 }
 
 function calcReadingTime(content: string): string {
@@ -101,22 +101,22 @@ export const BlogPost = () => {
 
             {/* Title */}
             <h1 className="text-4xl md:text-5xl font-bold mb-6 text-foreground leading-tight">
-              {post.titulo}
+              {post.title}
             </h1>
 
             {/* Meta Information */}
             <div className="flex flex-wrap items-center gap-6 text-muted-foreground mb-8">
               <div className="flex items-center gap-2">
                 <User className="w-4 h-4" />
-                <span>{post.autor}</span>
+                <span>{post.author}</span>
               </div>
               <div className="flex items-center gap-2">
                 <Calendar className="w-4 h-4" />
-                <span>{new Date(post.data_publicacao).toLocaleDateString('pt-BR')}</span>
+                <span>{new Date(post.date).toLocaleDateString('pt-BR')}</span>
               </div>
               <div className="flex items-center gap-2">
                 <Clock className="w-4 h-4" />
-                <span>{`${calcReadingTime(post.conteudo)} min`} de leitura</span>
+                <span>{`${calcReadingTime(post.content)} min`} de leitura</span>
               </div>
             </div>
 
@@ -137,8 +137,8 @@ export const BlogPost = () => {
           <div className="max-w-4xl mx-auto">
             <div className="relative h-64 md:h-96 overflow-hidden rounded-2xl">
               <img
-                src={post.imagem_destacada}
-                alt={post.titulo}
+                src={post.coverImage}
+                alt={post.title}
                 className="w-full h-full object-cover"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-background/20 to-transparent" />
@@ -154,7 +154,7 @@ export const BlogPost = () => {
             <div className="glass rounded-2xl p-8 md:p-12">
               <div 
                 className="prose prose-lg max-w-none text-foreground prose-headings:text-foreground prose-strong:text-foreground prose-a:text-primary prose-a:no-underline hover:prose-a:underline prose-ul:text-muted-foreground prose-ol:text-muted-foreground prose-li:text-muted-foreground"
-                dangerouslySetInnerHTML={{ __html: post.conteudo }}
+                dangerouslySetInnerHTML={{ __html: post.content }}
               />
             </div>
           </div>
@@ -176,9 +176,9 @@ export const BlogPost = () => {
                 {relatedPosts.map((relatedPost) => (
                   <article key={relatedPost.slug} className="glass rounded-2xl overflow-hidden hover-lift group">
                     <div className="relative h-48 overflow-hidden">
-                      <img
-                        src={relatedPost.imagem_destacada}
-                        alt={relatedPost.titulo}
+                    <img
+                        src={relatedPost.coverImage}
+                        alt={relatedPost.title}
                         className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                       />
                       <div className="absolute inset-0 bg-gradient-to-t from-background/60 to-transparent" />
@@ -186,10 +186,10 @@ export const BlogPost = () => {
 
                     <div className="p-6">
                       <h3 className="text-lg font-bold mb-2 text-foreground line-clamp-2 group-hover:text-primary transition-colors duration-300">
-                        {relatedPost.titulo}
+                        {relatedPost.title}
                       </h3>
                       <p className="text-muted-foreground text-sm mb-4 line-clamp-2">
-                        {relatedPost.resumo}
+                        {relatedPost.excerpt}
                       </p>
                       <Link
                         to={`/blog/${relatedPost.slug}`}


### PR DESCRIPTION
## Summary
- Map `blog_posts` table columns to English names in the blog routes
- Update blog UI components to consume `title`, `excerpt`, `content`, `coverImage`, `date`, and `author`

## Testing
- `node backend/testConnection.js` *(fails: connect ENETUNREACH)*
- `npm run lint` *(fails: Unexpected any in CaseDetail.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689d4db74198833098f5cd96f5ebb34f