### PR TITLE
chore: unify API routes and update checkout

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,33 +1,32 @@
+import dotenv from 'dotenv';
+dotenv.config(); // carrega .env ANTES de qualquer import que use process.env
+
 import express from 'express';
 import cors from 'cors';
 import morgan from 'morgan';
-import dotenv from 'dotenv';
-import path from 'path';
-import { fileURLToPath } from 'url';
 
-import blogPostsRoute from './routes/blogPosts.js';
-import casesRoute from './routes/cases.js';
-
-dotenv.config();
+import blogPostsRoute from './routes/blogPosts.js';  // GET /api/blog-posts, /api/blog-posts/:slug
+import casesRoute from './routes/cases.js';          // GET /api/cases,      /api/cases/:slug
+import checkoutRoute from './routes/checkout.js';    // POST /api/checkout   (se existir)
 
 const app = express();
+
 app.use(cors());
 app.use(express.json({ limit: '1mb' }));
 app.use(morgan('dev'));
 
-// healthcheck
+// healthcheck simples
 app.get('/api/health', (_req, res) => {
   res.json({ ok: true, env: process.env.NODE_ENV || 'production' });
 });
 
-// API
+// ROTAS DA API (cada uma no seu prefixo)
 app.use('/api/blog-posts', blogPostsRoute);
-app.use('/api/cases', casesRoute);
+app.use('/api/cases',      casesRoute);
+app.use('/api/checkout',   checkoutRoute); // deixe montado apenas se o arquivo existir
 
-// (opcional) servir estáticos somente se você optar por servir o front pelo Node.
-// No Plesk, vamos manter o Apache servindo / e deixar o Node apenas em /api.
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+// (opcional) rota 404 de API
+app.use('/api', (_req, res) => res.status(404).json({ error: 'not_found' }));
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {

--- a/backend/routes/blogPosts.js
+++ b/backend/routes/blogPosts.js
@@ -13,7 +13,7 @@ router.get('/', async (_req, res) => {
         slug,
         resumo AS excerpt,
         conteudo AS content,
-        imagem_destacada AS cover_image,
+        imagem_destacada AS coverImage,
         data_publicacao AS date,
         autor AS author
       FROM blog_posts
@@ -38,7 +38,7 @@ router.get('/:slug', async (req, res) => {
         slug,
         resumo AS excerpt,
         conteudo AS content,
-        imagem_destacada AS cover_image,
+        imagem_destacada AS coverImage,
         data_publicacao AS date,
         autor AS author
       FROM blog_posts

--- a/backend/routes/checkout.js
+++ b/backend/routes/checkout.js
@@ -1,15 +1,21 @@
-const express = require('express');
-const Stripe = require('stripe');
+import { Router } from 'express';
+import Stripe from 'stripe';
+
+const router = Router();
 
 const stripeSecret = process.env.STRIPE_SECRET_KEY;
-if (!stripeSecret) {
+let stripe = null;
+if (stripeSecret) {
+  stripe = new Stripe(stripeSecret, { apiVersion: '2023-10-16' });
+} else {
   console.error('STRIPE_SECRET_KEY not configured');
 }
-const stripe = new Stripe(stripeSecret || '', { apiVersion: '2023-10-16' });
 
-const router = express.Router();
+router.post('/', async (req, res) => {
+  if (!stripe) {
+    return res.status(500).json({ error: 'Stripe not configured' });
+  }
 
-router.post('/checkout', async (req, res) => {
   const { id } = req.body;
   console.log('[checkout] requested', id);
 
@@ -49,4 +55,4 @@ router.post('/checkout', async (req, res) => {
   }
 });
 
-module.exports = router;
+export default router;


### PR DESCRIPTION
## Summary
- load dotenv early and mount blog, cases, and checkout routes under /api
- convert checkout route to ES modules and guard against missing Stripe key
- expose blog cover images with camelCase alias

## Testing
- `node backend/index.js &` then `curl -s http://localhost:3000/api/health`


------
https://chatgpt.com/codex/tasks/task_e_689d557184cc8330aa5a2fed5414d17d