### PR TITLE
Align cases schema with database and add env defaults

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -4,4 +4,6 @@ DB_USER=winove
 DB_PASSWORD=9*19avmU0
 DB_NAME=fernando_winove_com_br_
 STRIPE_SECRET_KEY=sk_live_your_key_here
+PUBLIC_BASE_URL=https://winove.com.br
+USE_JSON_DB=false
 PORT=3333

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,3 +8,4 @@ DB_NAME=fernando_winove_com_br_
 # API
 PORT=3000
 PUBLIC_BASE_URL=https://winove.com.br
+USE_JSON_DB=false

--- a/backend/createBlogAndCasersTables.js
+++ b/backend/createBlogAndCasersTables.js
@@ -10,7 +10,7 @@ async function setupDatabase() {
   });
 
   const createPostsTable = `
-    CREATE TABLE IF NOT EXISTS posts (
+    CREATE TABLE IF NOT EXISTS blog_posts (
       id INT AUTO_INCREMENT PRIMARY KEY,
       titulo VARCHAR(255) NOT NULL,
       slug VARCHAR(255) UNIQUE NOT NULL,
@@ -31,18 +31,17 @@ async function setupDatabase() {
       coverImage TEXT,
       tags JSON,
       metrics JSON,
+      gallery JSON,
+      content LONGTEXT,
       client VARCHAR(255),
-      date DATETIME DEFAULT CURRENT_TIMESTAMP,
-      challenge TEXT,
-      solution TEXT,
-      results TEXT,
-      gallery JSON
+      category VARCHAR(255),
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
     );
   `;
 
   try {
     await connection.execute(createPostsTable);
-    console.log("✅ Tabela 'posts' criada com sucesso.");
+    console.log("✅ Tabela 'blog_posts' criada com sucesso.");
 
     await connection.execute(createCasesTable);
     console.log("✅ Tabela 'cases' criada com sucesso.");

--- a/backend/routes/cases.js
+++ b/backend/routes/cases.js
@@ -27,10 +27,20 @@ router.get('/', async (_req, res) => {
   try {
     const [rows] = await pool.query(`
       SELECT
-        id, title, slug, excerpt, coverImage, tags, metrics, gallery,
-        content, client, category, created_at
+        id,
+        titulo AS title,
+        slug,
+        resumo AS excerpt,
+        cover_image AS coverImage,
+        tags,
+        metrics,
+        galeria AS gallery,
+        conteudo AS content,
+        cliente AS client,
+        categoria AS category,
+        data_publicacao AS created_at
       FROM cases
-      ORDER BY created_at DESC
+      ORDER BY data_publicacao DESC
     `);
 
     const data = (rows || []).map((r) => ({
@@ -54,8 +64,18 @@ router.get('/:slug', async (req, res) => {
     const [rows] = await pool.query(
       `
       SELECT
-        id, title, slug, excerpt, coverImage, tags, metrics, gallery,
-        content, client, category, created_at
+        id,
+        titulo AS title,
+        slug,
+        resumo AS excerpt,
+        cover_image AS coverImage,
+        tags,
+        metrics,
+        galeria AS gallery,
+        conteudo AS content,
+        cliente AS client,
+        categoria AS category,
+        data_publicacao AS created_at
       FROM cases
       WHERE slug = ?
       LIMIT 1


### PR DESCRIPTION
## Summary
- use SQL aliases in cases route to handle Portuguese column names
- sync table creation script with expected blog and cases fields
- document base URL and DB mode in env examples

## Testing
- `npm test` *(fails: Missing script "test")*
- `node testConnection.js` *(fails: connect ENETUNREACH 168.75.84.128:3306)*

------
https://chatgpt.com/codex/tasks/task_e_689d5cfd7acc8330be6bf0e7069ae31c