### PR TITLE
Validate checkout product ID

### DIFF
--- a/backend/routes/checkout.js
+++ b/backend/routes/checkout.js
@@ -15,14 +15,18 @@ router.post('/', async (req, res) => {
   if (!stripe) {
     return res.status(500).json({ error: 'Stripe not configured' });
   }
-
-  const { id } = req.body;
-  console.log('[checkout] requested', id);
-
   const produtos = {
     template_restaurante: { name: 'Restaurant Deluxe', price: 12990 },
     template_consultorio: { name: 'Consultório Premium', price: 14990 },
   };
+
+  if (!req.body || typeof req.body.id !== 'string') {
+    console.warn('[checkout] id ausente ou inválido:', req.body?.id);
+    return res.status(400).json({ error: 'ID do produto ausente ou inválido' });
+  }
+
+  const { id } = req.body;
+  console.log('[checkout] requested', id);
 
   const produto = produtos[id];
   if (!produto) {


### PR DESCRIPTION
## Summary
- Validate existence of request body and ensure `id` is a string before processing checkout
- Return 400 error when product `id` is missing or unrecognized

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e08db38188330af8ced4a35afcab4