### PR TITLE
fix: remove top-level await for checkout route

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -25,8 +25,13 @@ app.use('/api/cases',      casesRoute);
 
 // monta rota de checkout apenas se a chave STRIPE_SECRET_KEY estiver definida
 if (process.env.STRIPE_SECRET_KEY) {
-  const { default: checkoutRoute } = await import('./routes/checkout.js');
-  app.use('/api/checkout', checkoutRoute);
+  import('./routes/checkout.js')
+    .then(({ default: checkoutRoute }) => {
+      app.use('/api/checkout', checkoutRoute);
+    })
+    .catch((err) => {
+      console.error('Erro ao carregar checkout:', err);
+    });
 }
 
 // (opcional) rota 404 de API


### PR DESCRIPTION
## Summary
- load Stripe checkout route without top-level await to avoid spawn failures

## Testing
- `npm test` *(fails: Missing script "test")*
- `DB_HOST=localhost DB_USER=user DB_PASSWORD=pass DB_NAME=test PORT=3333 node index.js`

------
https://chatgpt.com/codex/tasks/task_e_689e0d9e71a083308688426c10f6feb3