### PR TITLE
feat: allow loading images via CSP middleware

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -13,6 +13,13 @@ const app = express();
 app.use(cors());
 app.use(express.json({ limit: '1mb' }));
 app.use(morgan('dev'));
+app.use((req, res, next) => {
+  res.setHeader(
+    'Content-Security-Policy',
+    "default-src 'self'; img-src 'self' data: blob: https://winove.com.br;"
+  );
+  next();
+});
 
 // healthcheck simples
 app.get('/api/health', (_req, res) => {


### PR DESCRIPTION
## Summary
- add Content-Security-Policy header middleware to permit local and winove.com.br images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_689e3ae664d883308bc3fdb93b690888